### PR TITLE
feat : 특정 주기마다 상담 유형 별 순위 기능 구현

### DIFF
--- a/src/main/java/com/project/doongdoong/domain/analysis/service/AnalysisServiceImp.java
+++ b/src/main/java/com/project/doongdoong/domain/analysis/service/AnalysisServiceImp.java
@@ -14,7 +14,6 @@ import com.project.doongdoong.domain.question.repository.QuestionRepository;
 import com.project.doongdoong.domain.question.service.QuestionProvidable;
 import com.project.doongdoong.domain.user.exeception.UserNotFoundException;
 import com.project.doongdoong.domain.user.model.SocialIdentifier;
-import com.project.doongdoong.domain.user.model.SocialType;
 import com.project.doongdoong.domain.user.model.User;
 import com.project.doongdoong.domain.user.repository.UserRepository;
 import com.project.doongdoong.domain.voice.exception.VoiceNotFoundException;
@@ -95,7 +94,7 @@ public class AnalysisServiceImp implements AnalysisService {
         Map<QuestionContent, String> voiceMap = mapVoiceToQuestionInformation(findVoices);
         List<String> questionVoiceAccessUrls = findUrlsByMatchingQuestionContentsWithVoice(questionContents, voiceMap);
 
-        List<String> answerContents = findAnswerConetentsByMatchingQuestionWithAnswer(questions);
+        List<String> answerContents = findAnswerContentsByMatchingQuestionWithAnswer(questions);
 
         return AnalysisDetailResponse.of(analysisId, findAnalysis.getFeelingState(), findAnalysis.getCreatedTime().format(DateTimeFormatter.ofPattern(DEFAULT_DATE_TIME_FORMAT)),
                 questionTexts, questionIds, questionVoiceAccessUrls, answerContents);
@@ -221,7 +220,7 @@ public class AnalysisServiceImp implements AnalysisService {
         return uniqueValue.split("_");
     }
 
-    private List<String> findAnswerConetentsByMatchingQuestionWithAnswer(List<Question> questions) {
+    private List<String> findAnswerContentsByMatchingQuestionWithAnswer(List<Question> questions) {
         return questions.stream()
                 .map(question ->
                         Optional.ofNullable(question.getAnswer())

--- a/src/main/java/com/project/doongdoong/domain/counsel/Application.java
+++ b/src/main/java/com/project/doongdoong/domain/counsel/Application.java
@@ -1,0 +1,16 @@
+package com.project.doongdoong.domain.counsel;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class Application implements CommandLineRunner {
+    private final RedisRebuilder redisRebuilder;
+
+    @Override
+    public void run(String... args) throws Exception {
+        redisRebuilder.rebuildRedisFromRdb();
+    }
+}

--- a/src/main/java/com/project/doongdoong/domain/counsel/Application.java
+++ b/src/main/java/com/project/doongdoong/domain/counsel/Application.java
@@ -2,10 +2,12 @@ package com.project.doongdoong.domain.counsel;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Profile("!test")
 public class Application implements CommandLineRunner {
     private final RedisRebuilder redisRebuilder;
 

--- a/src/main/java/com/project/doongdoong/domain/counsel/RedisRebuilder.java
+++ b/src/main/java/com/project/doongdoong/domain/counsel/RedisRebuilder.java
@@ -1,0 +1,42 @@
+package com.project.doongdoong.domain.counsel;
+
+import com.project.doongdoong.domain.counsel.model.CounselCacheKey;
+import com.project.doongdoong.domain.counsel.repository.CounselRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisRebuilder {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final CounselRepository counselRepository; // 또는 JPA Query로 구현
+
+    public void rebuildRedisFromRdb() {
+        List<Object[]> results = counselRepository.countCounselGroupByDateAndType();
+
+        for (Object[] row : results) {
+            LocalDate date = ((java.sql.Date) row[0]).toLocalDate();
+            String type = row[1].toString();
+            Long count = (Long) row[2];
+
+            // 날짜별 key
+            String dailyKey = CounselCacheKey.generateDailyKey(date);
+            redisTemplate.opsForZSet().incrementScore(dailyKey, type, count);
+
+            // TTL 설정: 오늘 기준 7일 이내만 TTL 설정
+            if (!date.isBefore(LocalDate.now().minusDays(7))) {
+                redisTemplate.expire(dailyKey, 7, TimeUnit.DAYS);
+            }
+
+            // 전체 key
+            String totalKey = CounselCacheKey.generateTotalKey();
+            redisTemplate.opsForZSet().incrementScore(totalKey, type, count);
+        }
+    }
+}

--- a/src/main/java/com/project/doongdoong/domain/counsel/controller/CounselController.java
+++ b/src/main/java/com/project/doongdoong/domain/counsel/controller/CounselController.java
@@ -6,6 +6,7 @@ import com.project.doongdoong.domain.counsel.dto.response.CounselDetailResponse;
 import com.project.doongdoong.domain.counsel.dto.response.CounselListResponse;
 import com.project.doongdoong.domain.counsel.dto.response.CounselResultResponse;
 import com.project.doongdoong.domain.counsel.service.CounselService;
+import com.project.doongdoong.domain.counsel.service.CounselStatisticsService;
 import com.project.doongdoong.global.annotation.CurrentUser;
 import com.project.doongdoong.global.common.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
@@ -26,6 +27,7 @@ import java.net.URI;
 public class CounselController {
 
     private final CounselService counselService;
+    private final CounselStatisticsService counselStatisticsService;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
@@ -53,8 +55,10 @@ public class CounselController {
     public ApiResponse<CounselListResponse> findCounsels(@CurrentUser String uniqueValue,
                                                          @RequestParam(name = "pageNumber", required = false, defaultValue = "1")
                                                          @Valid @Min(value = 1, message = "페이지 시작은 최소 1입니다.") int pageNumber) {
+        CounselListResponse counselListResponse = counselService.findCounsels(uniqueValue, pageNumber);
+        CounselRankList combinedRanking = counselStatisticsService.getCombinedRanking();
 
-        return ApiResponse.of(HttpStatus.OK, null, counselService.findCounsels(uniqueValue, pageNumber));
+        return ApiResponse.of(HttpStatus.OK, null, CounselListResponse.of(counselListResponse, combinedRanking));
     }
 
 

--- a/src/main/java/com/project/doongdoong/domain/counsel/dto/response/CounselListResponse.java
+++ b/src/main/java/com/project/doongdoong/domain/counsel/dto/response/CounselListResponse.java
@@ -1,5 +1,7 @@
 package com.project.doongdoong.domain.counsel.dto.response;
 
+import com.project.doongdoong.domain.counsel.dto.CounselRankList;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +10,7 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class CounselListResponse {
 
     private int currentPage;
@@ -15,6 +18,7 @@ public class CounselListResponse {
     private int totalPage;
     private long totalElements;
     private List<CounselResponse> counselContent;
+    private CounselRankList counselRankList;
 
     @Builder
     public CounselListResponse(int currentPage, int numberPerPage, int totalPage, long totalElements, List<CounselResponse> counselContent) {
@@ -23,5 +27,16 @@ public class CounselListResponse {
         this.totalPage = totalPage;
         this.totalElements = totalElements;
         this.counselContent = counselContent;
+    }
+
+    public static CounselListResponse of(CounselListResponse response, CounselRankList combinedRanking) {
+        return new CounselListResponse(
+                response.currentPage,
+                response.getNumberPerPage(),
+                response.totalPage,
+                response.totalElements,
+                response.getCounselContent(),
+                combinedRanking
+        );
     }
 }

--- a/src/main/java/com/project/doongdoong/domain/counsel/repository/CounselRepository.java
+++ b/src/main/java/com/project/doongdoong/domain/counsel/repository/CounselRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,5 +16,12 @@ public interface CounselRepository extends JpaRepository<Counsel, Long>, Counsel
 
     @Query("select c from Counsel c left outer join fetch c.analysis where c.id = :counselId")
     Optional<Counsel> findWithAnalysisById(@Param("counselId") Long counselId);
+
+    @Query(value = """
+            SELECT DATE(created_time) AS date, counsel_type, COUNT(*) AS count
+            FROM counsel
+            GROUP BY DATE(created_time), counsel_type
+            """, nativeQuery = true)
+    List<Object[]> countCounselGroupByDateAndType();
 
 }

--- a/src/main/java/com/project/doongdoong/domain/counsel/repository/querydsl/CounselCustomRepositoryImpl.java
+++ b/src/main/java/com/project/doongdoong/domain/counsel/repository/querydsl/CounselCustomRepositoryImpl.java
@@ -29,15 +29,15 @@ public class CounselCustomRepositoryImpl implements CounselCustomRepository {
         List<Counsel> content = queryFactory
                 .selectFrom(counsel)
                 .leftJoin(counsel.analysis, analysis).fetchJoin()
-                .where(userEq(user))
+                //.where(userEq(user))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
         JPAQuery<Long> countQuery = queryFactory
                 .select(counsel.count())
-                .from(counsel)
-                .where(userEq(user));
+                .from(counsel);
+                //.where(userEq(user));
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }

--- a/src/main/java/com/project/doongdoong/domain/counsel/service/CounselStatisticsServiceImpl.java
+++ b/src/main/java/com/project/doongdoong/domain/counsel/service/CounselStatisticsServiceImpl.java
@@ -5,7 +5,6 @@ import com.project.doongdoong.domain.counsel.model.CounselRank;
 import com.project.doongdoong.domain.counsel.model.CounselType;
 import com.project.doongdoong.global.util.CounselRankingCache;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -14,10 +13,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CounselStatisticsServiceImpl implements CounselStatisticsService {
 
-    private final RedisTemplate<String, Object> redisTemplate;
     private final CounselRankingCache rankingCache;
-
-    private static final int ONE = 1, WEEKS = 7;
 
     @Override
     public void incrementTypeCount(CounselType counselType) {

--- a/src/main/java/com/project/doongdoong/global/util/CounselRankingRedis.java
+++ b/src/main/java/com/project/doongdoong/global/util/CounselRankingRedis.java
@@ -22,15 +22,15 @@ public class CounselRankingRedis implements CounselRankingCache {
 
     @Override
     public void incrementTodayCount(CounselType type) {
-        String key = CounselCacheKey.generateTotalKey();
+        String key = CounselCacheKey.generateDailyKey(LocalDate.now());
         redisTemplate.opsForZSet().incrementScore(key, type.name(), ONE);
+        redisTemplate.expire(key, WEEKS, TimeUnit.DAYS);
     }
 
     @Override
     public void incrementTotalCount(CounselType type) {
-        String key = CounselCacheKey.generateDailyKey(LocalDate.now());
+        String key = CounselCacheKey.generateTotalKey();
         redisTemplate.opsForZSet().incrementScore(key, type.name(), ONE);
-        redisTemplate.expire(key, WEEKS, TimeUnit.DAYS);
     }
 
     @Override

--- a/src/main/java/com/project/doongdoong/global/util/WebClientUtil.java
+++ b/src/main/java/com/project/doongdoong/global/util/WebClientUtil.java
@@ -154,9 +154,9 @@ public class WebClientUtil {
         /**
          * Mock 용도와 같은 테스트 용도 주석 코드
          */
-        /*CounselAiResponse counselAiResponse = new CounselAiResponse("답변입니다.", "임시 imageUrl 입니다.");
-        return  counselAiResponse;*/
-        return defaultWebClient
+        CounselAiResponse counselAiResponse = new CounselAiResponse("답변입니다.", "임시 imageUrl 입니다.");
+        return  counselAiResponse;
+        /*return defaultWebClient
                 .post()
                 .uri(lambdaConsultApiUrl)
                 .bodyValue(body)
@@ -167,6 +167,6 @@ public class WebClientUtil {
                                 .map(ExternalApiCallException::new)
                 )
                 .bodyToMono(CounselAiResponse.class)
-                .block();
+                .block();*/
     }
 }

--- a/src/test/java/com/project/doongdoong/domain/analysis/model/AnalysisTest.java
+++ b/src/test/java/com/project/doongdoong/domain/analysis/model/AnalysisTest.java
@@ -72,7 +72,6 @@ class AnalysisTest {
         assertThat(result).isTrue();
     }
 
-
     private Analysis createAnalysis(LocalDate analyzeDate) {
         Analysis analysis = Analysis.builder()
                 .build();

--- a/src/test/java/com/project/doongdoong/module/ControllerTestSupport.java
+++ b/src/test/java/com/project/doongdoong/module/ControllerTestSupport.java
@@ -6,6 +6,7 @@ import com.project.doongdoong.domain.analysis.service.AnalysisService;
 import com.project.doongdoong.domain.answer.service.AnswerService;
 import com.project.doongdoong.domain.counsel.controller.CounselController;
 import com.project.doongdoong.domain.counsel.service.CounselService;
+import com.project.doongdoong.domain.counsel.service.CounselStatisticsService;
 import com.project.doongdoong.domain.user.controller.UserController;
 import com.project.doongdoong.domain.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,8 @@ import org.springframework.test.web.servlet.MockMvc;
         protected MockMvc mockMvc;
         @MockBean
         protected CounselService counselService;
+        @MockBean
+        CounselStatisticsService counselStatisticsService;
         @MockBean
         protected AnalysisService analysisService;
         @MockBean


### PR DESCRIPTION
🚀 **Pull Request**
---

### 🔗 관련 이슈
<!-- 관련된 Issue 번호를 적어주세요 (예: Fix #123, Close #456) -->
- Resolved: #14 

### 📌 작업 내용
상담하기 기능에 대해 각 상담 유형 별로 특정 주기를 기준으로 횟수 순위 기능 구현
1. Redis Sorted Set 자료형 활용, 데이터 정합성을 최대한 맞춰주기 위해 각 key에 대해 union 연산
2. 임시로 Redis 데이터 삭제 등 장애 상황에 대응하여, 스프링 서버 배포할때 체크하여 반영

[플로우]
<img width="695" alt="image" src="https://github.com/user-attachments/assets/98f07b32-b10b-4155-81e1-eebb544500d1" />




### 📢 공유
[정리 링크](https://radical-ocean-d1e.notion.site/Redis-216fb93e052980f8b9c4ddae54a42251?pvs=74)


